### PR TITLE
Fixing transparency on Linux and Windows 10 /11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 screenboard-darwin-x64/
 packages/
 .DS_Store
+**/*.log

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ While it's running in your terminal, you can do a set of commands:
 
 You can customize `your own shortcuts` in `./src/shortcuts.js` file.
 
+## 😢 Limitations
+
+There are some limitations about the transparency on Electron. You can check out [here](https://www.electronjs.org/docs/latest/tutorial/window-customization#limitations).
+
+On Windows OS:
+
+* Transparent windows will not work when DWM is disabled.
+* Transparent windows can not be maximized using the Windows system menu or by double clicking the title bar. The reasoning behind this can be seen on PR [#28207](https://github.com/electron/electron/pull/28207).
+
 ---
 
 ## 🕵🏾‍♂️ Inspiration ...
@@ -92,7 +101,8 @@ Contributions, issues and feature requests are welcome!<br />Feel free to check 
 ## 🧪 Tested in
 
 - MacOS
-- Windows(by @davidlpc1)
+- Linux \[Ubuntu 20.04.4 LTS\](by @rrogovski)
+- Windows 10/11 (by @davidlpc1 / @rrogovski)
 
 ## ✨ Show your support
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Contributions, issues and feature requests are welcome!<br />Feel free to check 
 ## 🧪 Tested in
 
 - MacOS
-- Linux \[Ubuntu 20.04.4 LTS\](by @rrogovski)
-- Windows 10/11 (by @davidlpc1 / @rrogovski)
+- Linux \[Ubuntu 20.04.4 LTS\](by [@rrogovski](https://github.com/rrogovski))
+- Windows 10/11 (by [@davidlpc1](https://github.com/davidlpc1) / [@rrogovski](https://github.com/rrogovski))
 
 ## ✨ Show your support
 

--- a/build/index.js
+++ b/build/index.js
@@ -30,6 +30,11 @@ function createShortcuts() {
     const { reopen = 'Alt+Shift+w' } = require('../src/shortcuts.js');
     electron_1.globalShortcut.register(reopen, WindowVisibility.toggle);
 }
+// To enable transparency on Linux
+if (process.platform === "linux") {
+    electron_1.app.commandLine.appendSwitch('enable-transparent-visuals');
+    electron_1.app.disableHardwareAcceleration();
+}
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,12 +36,19 @@ function createShortcuts() {
   globalShortcut.register(reopen, WindowVisibility.toggle)
 }
 
+// To enable transparency on Linux
+if(process.platform === "linux") {
+  app.commandLine.appendSwitch('enable-transparent-visuals');
+  app.disableHardwareAcceleration();
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app
   .whenReady()
-  .then(() => setTimeout(createWindow, 200))
+  .then(() => {})
+  .then(() => setTimeout(createWindow, 400))
   .then(createShortcuts)
 
 // Quit when all windows are closed.
@@ -59,7 +66,7 @@ function recreateWindow() {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (BrowserWindow.getAllWindows().length === 0) {
-    setTimeout(createWindow, 200)
+    setTimeout(createWindow, 400)
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,8 +9,9 @@ function createWindow() {
 
   // Create the browser window.
   win = new BrowserWindow({
-    width: dimensions.width,
-    height: dimensions.height,
+    // Trick to be transparent on win10/11
+    width: dimensions.width-1,
+    height: dimensions.height-1,
     transparent: true,
     frame: false,
     titleBarStyle: 'customButtonsOnHover',
@@ -47,8 +48,7 @@ if(process.platform === "linux") {
 // Some APIs can only be used after this event occurs.
 app
   .whenReady()
-  .then(() => {})
-  .then(() => setTimeout(createWindow, 400))
+  .then(() => setTimeout(createWindow, 200))
   .then(createShortcuts)
 
 // Quit when all windows are closed.
@@ -66,7 +66,7 @@ function recreateWindow() {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (BrowserWindow.getAllWindows().length === 0) {
-    setTimeout(createWindow, 400)
+    setTimeout(createWindow, 200)
   }
 }
 


### PR DESCRIPTION
I have been try to use it on Linux, but I face a problem with transparency. So i fixed it, but to be sure the still working on Windows 10/11, I decided to testing on this OSs to, and it suprised me when don't work too. So i did make a little trick to be transparent on Windows 10/11.

***Have to be tested on MacOS***

Some references:

https://stackoverflow.com/questions/54763647/transparent-windows-on-linux-electron
https://github.com/electron/electron/issues/2170#issuecomment-944872908